### PR TITLE
Add bought items + fixes

### DIFF
--- a/Data/ConnectionData.cs
+++ b/Data/ConnectionData.cs
@@ -25,6 +25,7 @@ namespace LunacidAP.Data
         public static Dictionary<string, string> TraversedEntrances { get; set; } = new() { };
         public static SortedDictionary<long, ArchipelagoItem> ScoutedLocations = new(){};
         public static List<string> EnteredScenes = new(){};
+        public static HashSet<string> BoughtItems = new(){};
         public static List<ReceivedGift> ReceivedGifts = new(){};
         public static Dictionary<string, string> ItemColors = new(){};
         public static Dictionary<string, List<RandomizedEnemyData>> RandomEnemyData = new(){};
@@ -32,7 +33,7 @@ namespace LunacidAP.Data
         public static void WriteConnectionData(string hostName, int port, string slotName, string password, int storedLevel = 0, int storedExperience = 0,
         int seed = 0, int index = 0, bool deathLink = false, int cheatedCount = -1, Dictionary<string, ReceivedItem> receivedItems = null, List<long> completedLocations = null, 
         Dictionary<string, string> communionHints = null, Dictionary<string, string> elements = null, Dictionary<string, string> entrances = null,
-        Dictionary<string, string> traversedEntrances = null, SortedDictionary<long, ArchipelagoItem> scouts = null, List<string> enteredScenes = null, List<ReceivedGift> receivedGifts = null, 
+        Dictionary<string, string> traversedEntrances = null, SortedDictionary<long, ArchipelagoItem> scouts = null, List<string> enteredScenes = null, HashSet<string> boughtItems = null, List<ReceivedGift> receivedGifts = null, 
         Dictionary<string, string> itemColors = null, Dictionary<string, List<RandomizedEnemyData>> randomEnemyData = null)
         {
             HostName = hostName;
@@ -89,6 +90,10 @@ namespace LunacidAP.Data
             {
                 EnteredScenes = enteredScenes;
             }
+            if (boughtItems is not null)
+            {
+                BoughtItems = boughtItems;
+            }
             if (receivedGifts is not null)
             {
                 ReceivedGifts = receivedGifts;
@@ -123,6 +128,7 @@ namespace LunacidAP.Data
             TraversedEntrances = new(){};
             ScoutedLocations = new(){};
             EnteredScenes = new(){};
+            BoughtItems = new(){};
             ReceivedGifts = new(){};
             ItemColors = new(){};
             RandomEnemyData = new(){};

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+        <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+    </packageSources>
+</configuration>

--- a/Patches/SaveHandler.cs
+++ b/Patches/SaveHandler.cs
@@ -56,6 +56,7 @@ namespace LunacidAP
                 TraversedEntrances = ConnectionData.TraversedEntrances,
                 ScoutedLocations = ConnectionData.ScoutedLocations,
                 EnteredScenes = ConnectionData.EnteredScenes,
+                BoughtItems = ConnectionData.BoughtItems,
                 ReceivedGifts = ConnectionData.ReceivedGifts,
                 RandomEnemyData = ConnectionData.RandomEnemyData,
             };
@@ -91,8 +92,8 @@ namespace LunacidAP
                     var loadedSave = JsonConvert.DeserializeObject<APSaveData>(text);
                     ConnectionData.WriteConnectionData(loadedSave.HostName, loadedSave.Port, loadedSave.SlotName, loadedSave.Password, loadedSave.StoredLevel, loadedSave.StoredExperience,
                     loadedSave.Seed, loadedSave.Index, loadedSave.DeathLink, loadedSave.CheatCount, loadedSave.ObtainedItems, loadedSave.CheckedLocations, 
-                    loadedSave.CommunionHints, loadedSave.Elements, loadedSave.Entrances, loadedSave.TraversedEntrances, loadedSave.ScoutedLocations, loadedSave.EnteredScenes, loadedSave.ReceivedGifts,
-                    loadedSave.ItemColors, loadedSave.RandomEnemyData);
+                    loadedSave.CommunionHints, loadedSave.Elements, loadedSave.Entrances, loadedSave.TraversedEntrances, loadedSave.ScoutedLocations, loadedSave.EnteredScenes, loadedSave.BoughtItems,
+                    loadedSave.ReceivedGifts, loadedSave.ItemColors, loadedSave.RandomEnemyData);
                     _log.LogInfo($"We have {loadedSave.StoredLevel} vs {ConnectionData.StoredLevel}");
                     return;
                 }
@@ -129,6 +130,7 @@ namespace LunacidAP
         public Dictionary<string, string> TraversedEntrances;
         public SortedDictionary<long, ArchipelagoItem> ScoutedLocations;
         public List<string> EnteredScenes;
+        public HashSet<string> BoughtItems;
         public List<ReceivedGift> ReceivedGifts;
         public Dictionary<string, string> ItemColors;
         public Dictionary<string, List<RandomizedEnemyData>> RandomEnemyData;

--- a/Patches/ShopHandler.cs
+++ b/Patches/ShopHandler.cs
@@ -313,26 +313,33 @@ namespace LunacidAP
         {
             var sceneName = __instance.gameObject.scene.name;
             __instance.INV[which].cost = DetermineItemCost(__instance.INV[which], sceneName);
-            if (!ArchipelagoClient.AP.SlotData.Shopsanity)
+            var objectName = __instance.INV[which].OBJ.name;
+
+            if (ShopLocations.All(x => x.GameObjectName == __instance.INV[which].OBJ.name) ||
+                __instance.INV[which].cost > __instance.CON.CURRENT_PL_DATA.GOLD)
             {
                 return true;
             }
-            if (LunacidLocations.ShopLocations.Any(x => x.GameObjectName == __instance.INV[which].OBJ.name) &&
-            __instance.INV[which].cost <= __instance.CON.CURRENT_PL_DATA.GOLD)
+            
+            if (!ArchipelagoClient.AP.SlotData.Shopsanity)
             {
-                var objectName = __instance.INV[which].OBJ.name;
-                var apLocation = DetermineShopLocation(sceneName, objectName);
-                var location = +apLocation.APLocationID;
-                var locationInfo = ArchipelagoClient.AP.ScoutLocation(location);
-                var slotNameofItemOwner = locationInfo.SlotName;
-                if (ConnectionData.SlotName != slotNameofItemOwner)
-                {
-                    var itemName = locationInfo.Name;
-                    __instance.CON.PAPPY.POP($"Found {itemName} for {slotNameofItemOwner}", 1f, 0);
-                }
-                ArchipelagoClient.AP.Session.Locations.CompleteLocationChecks(location);
-                ConnectionData.CompletedLocations.Add(location);
+                ConnectionData.BoughtItems.Add(objectName);
+                ArchipelagoClient.AP.Session.DataStorage[Scope.Slot, "BoughtItems"] = ConnectionData.BoughtItems.ToArray();
+                
+                return true;
             }
+            
+            var apLocation = DetermineShopLocation(sceneName, objectName);
+            var location = +apLocation.APLocationID;
+            var locationInfo = ArchipelagoClient.AP.ScoutLocation(location);
+            var slotNameofItemOwner = locationInfo.SlotName;
+            if (ConnectionData.SlotName != slotNameofItemOwner)
+            {
+                var itemName = locationInfo.Name;
+                __instance.CON.PAPPY.POP($"Found {itemName} for {slotNameofItemOwner}", 1f, 0);
+            }
+            ArchipelagoClient.AP.Session.Locations.CompleteLocationChecks(location);
+            ConnectionData.CompletedLocations.Add(location);
             return true;
         }
 

--- a/Patches/TeleportHandler.cs
+++ b/Patches/TeleportHandler.cs
@@ -66,7 +66,6 @@ namespace LunacidAP
         {
             var currentWarp = new WarpDestinations.WarpData(__instance.LVL, __instance.POS, __instance.ROT);
             var eredWarp = HandleEntranceRandomizer(currentWarp);
-
             var finalWarp = FixWarps(eredWarp);
 
             _log.LogInfo($"{__instance.gameObject.scene.name} to {finalWarp.Scene}");
@@ -80,12 +79,13 @@ namespace LunacidAP
                     return false;
                 }
             }
-
-                __instance.LVL = finalWarp.Scene;
+            else
+            {
+                UpdateTraversedEntrancesAP(currentWarp);
+            }
+            __instance.LVL = finalWarp.Scene;
             __instance.POS = finalWarp.Position;
             __instance.ROT = finalWarp.Rotation;
-
-            UpdateTraversedEntrancesAP(currentWarp);
 
             return true;
         }
@@ -170,14 +170,14 @@ namespace LunacidAP
                 return;
             }
 
-            //_log.LogInfo("from: " + fromString);
+            _log.LogInfo("from: " + fromString);
 
             if (!ConnectionData.Entrances.TryGetValue(fromString, out var toString))
-                {
-                    //_log.LogError("to:   unknown");
-                    return;
-                }
-            //_log.LogInfo("to:   " + toString);
+            {
+                _log.LogError("to:   unknown");
+                return;
+            }
+            _log.LogInfo("to:   " + toString);
 
             if (toString == "NULL" || fromString == toString)
             {


### PR DESCRIPTION
added the BoughtItems DataStorage object keeping track of items bought outside of AP context.
changed the TraversedEntrances code by not calling the function when going from WR -> GWS (for some reason it counts as entering from HB)
added NuGet.config for development purposes, now it always knows the BepInEx source and won't freak out.